### PR TITLE
Fixes a typo in ReduceLROnPlateau doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed bug where aggregate predictions couldn't handle empty list
 - Fixed a bug where Runtime Errors on forward weren't handled properly
 - Fixed a bug where exceptions on forward wouldn't print the traceback properly
+- Fixed a documentation mistake whereby ReduceLROnPlateau was said to increase learning rate
 
 ## [0.4.0] - 2019-07-05
 ### Added

--- a/torchbearer/callbacks/torch_scheduler.py
+++ b/torchbearer/callbacks/torch_scheduler.py
@@ -165,8 +165,8 @@ class ReduceLROnPlateau(TorchScheduler):
         >>> from torchbearer import Trial
         >>> from torchbearer.callbacks import ReduceLROnPlateau
 
-        >>> # Example scheduler which multiplies the learning rate by 10 on plateaus of 5 epochs without significant
-        >>> # validation loss decrease
+        >>> # Example scheduler which divides the learning rate by 10 on plateaus of 5 epochs without significant
+        >>> # validation loss decrease, in order to stop overshooting the local minima. new_lr = lr * factor
         >>> scheduler = ReduceLROnPlateau(monitor='val_loss', factor=0.1, patience=5)
         >>> trial = Trial(None, callbacks=[scheduler], metrics=['loss'], verbose=2).for_steps(10).for_val_steps(10).run(1)
 


### PR DESCRIPTION
This just fixes a typo in the documentation of ReduceLROnPlateau which stated that each time the learning rate was stagnating it would get multiplied by 10, whilst in reality this will divide it by 10 to avoid overshooting local minima [according to PyTorch doc](https://pytorch.org/docs/master/optim.html#torch.optim.lr_scheduler.ReduceLROnPlateau).