### PR TITLE
Allow state info in filename of saved images from imaging callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Allow imaging callback's `to_file` to use state information in the file name
 ### Changed
 ### Deprecated
 ### Removed

--- a/tests/callbacks/imaging/test_imaging.py
+++ b/tests/callbacks/imaging/test_imaging.py
@@ -16,7 +16,7 @@ class TestHandlers(TestCase):
     def test_to_file(self, pil):
         handler = imaging.imaging._to_file('test')
         mock = MagicMock()
-        handler(mock, 0, {})
+        handler(mock, 0, {torchbearer.METRICS: {}})
         mock.mul.assert_called_once_with(255)
         mock.mul().clamp.assert_called_once_with(0, 255)
         self.assertTrue(mock.mul().clamp().byte.call_count == 1)

--- a/tests/callbacks/imaging/test_imaging.py
+++ b/tests/callbacks/imaging/test_imaging.py
@@ -16,7 +16,7 @@ class TestHandlers(TestCase):
     def test_to_file(self, pil):
         handler = imaging.imaging._to_file('test')
         mock = MagicMock()
-        handler(mock, 0, '')
+        handler(mock, 0, {})
         mock.mul.assert_called_once_with(255)
         mock.mul().clamp.assert_called_once_with(0, 255)
         self.assertTrue(mock.mul().clamp().byte.call_count == 1)

--- a/torchbearer/callbacks/imaging/imaging.py
+++ b/torchbearer/callbacks/imaging/imaging.py
@@ -7,10 +7,16 @@ import torch
 def _to_file(filename):
     from PIL import Image
 
-    def handler(image, index, _):
+    def handler(image, index, model_state):
+        state = {}
+        state.update(model_state)
+        state.update(model_state[torchbearer.METRICS])
+
+        string_state = {str(key): state[key] for key in state.keys()}
+
         ndarr = image.mul(255).clamp(0, 255).byte().permute(1, 2, 0).cpu().numpy()
         im = Image.fromarray(ndarr)
-        im.save(filename.format(index=str(index)))
+        im.save(filename.format(index=str(index), **string_state))
 
     return handler
 


### PR DESCRIPTION
You might want to use the imaging callbacks to write a file every epoch, but the original `to_file` method didn't expand the state dict into the formatter, so you couldn't change the filename. This fixes that.